### PR TITLE
venue: Fix GitHub auth with octokit

### DIFF
--- a/nusmods-venue-github-hook/__main__.js
+++ b/nusmods-venue-github-hook/__main__.js
@@ -1,8 +1,8 @@
 const git = require('isomorphic-git');
 const axios = require('axios');
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 
-const octokit = new Octokit();
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
 const codeBlock = (text, lang = '') =>
   '```' + lang + '\n' + text + '\n```';
@@ -45,11 +45,6 @@ module.exports = async (
   debug = false, 
   context,
 ) => {
-  octokit.authenticate({
-    type: 'oauth',
-    token: process.env.GITHUB_TOKEN,
-  });
-  
   console.log({ venue, room, latlng, floor, comment, reporterName, reporterEmail });
   
   // Get current version of the venue


### PR DESCRIPTION
GitHub changed their authentication scheme a while back which broke our
functions. Update the octokit package to use the new scheme.

*References*
GitHub announcement: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
octokit auth docs: https://octokit.github.io/rest.js/v19#authentication
